### PR TITLE
Map dependencies for project to a single GitHub manifest 

### DIFF
--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/base/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/base/BaseExtractorTest.groovy
@@ -83,21 +83,7 @@ abstract class BaseExtractorTest extends BaseIntegrationSpec {
         return json["manifests"] as Map
     }
 
-    protected String manifestKey(Map args) {
-        String build = args.getOrDefault("build", "")
-        String project = args.getOrDefault("project", "")
-        if (build.isEmpty() && project.isEmpty()) {
-            project = ":"
-        }
-        String configuration = args.get("configuration")
-        if (!configuration) {
-            throw new IllegalArgumentException("Missing 'configuration' parameter")
-        }
-        return "project ${build}${project} [${configuration}]"
-    }
-
-    protected Map jsonRepositorySnapshot(Map args) {
-        String manifestName = manifestKey(args)
+    protected Map jsonManifest(String manifestName) {
         Map manifests = jsonManifests()
         assert manifests.keySet().contains(manifestName)
         Map manifest = manifests[manifestName] as Map

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/MultiProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/MultiProjectDependencyExtractorTest.groovy
@@ -57,7 +57,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
         then:
         def manifests = jsonManifests()
         manifests.size() == 3
-        def parentRuntimeClasspath = jsonRepositorySnapshot(configuration: "runtimeClasspath")
+        def parentRuntimeClasspath = jsonManifest("project :")
         def parentRuntimeClasspathFile = parentRuntimeClasspath.file as Map
         parentRuntimeClasspathFile.source_location == "build.gradle"
         def parentClasspathResolved = parentRuntimeClasspath.resolved as Map
@@ -68,7 +68,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
             dependencies == []
         }
         subprojects.each { name ->
-            def runtimeClasspath = jsonRepositorySnapshot(project: ':' + name, configuration: "runtimeClasspath")
+            def runtimeClasspath = jsonManifest("project :${name}")
             def runtimeClasspathFile = runtimeClasspath.file as Map
             runtimeClasspathFile.source_location == name + "/build.gradle"
             def classpathResolved = runtimeClasspath.resolved as Map
@@ -112,7 +112,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
         def manifests = jsonManifests()
         if (resolveProjectA) {
             manifests.size() == 2
-            def aRuntimeClasspath = jsonRepositorySnapshot(project: ":a", configuration: "runtimeClasspath")
+            def aRuntimeClasspath = jsonManifest("project :a")
             def aRuntimeClasspathFile = aRuntimeClasspath.file as Map
             aRuntimeClasspathFile.source_location == "a/build.gradle"
             def aClasspathResolved = aRuntimeClasspath.resolved as Map
@@ -125,7 +125,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
         } else {
             manifests.size() == 1
         }
-        def bRuntimeClasspath = jsonRepositorySnapshot(project: ":b", configuration: "runtimeClasspath")
+        def bRuntimeClasspath = jsonManifest("project :b")
         def bRuntimeClasspathFile = bRuntimeClasspath.file as Map
         bRuntimeClasspathFile.source_location == "b/build.gradle"
         def bClasspathResolved = bRuntimeClasspath.resolved as Map
@@ -191,7 +191,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
         def aTestProjectPurl = "pkg:maven/org.test/a@1.0"
         def bTestProjectPurl = "pkg:maven/org.test/b@1.0"
 
-        def aCompileClasspath = jsonRepositorySnapshot(project: ":a", configuration: "compileClasspath")
+        def aCompileClasspath = jsonManifest("project :a")
         def aCompileClasspathFile = aCompileClasspath.file as Map
         aCompileClasspathFile.source_location == "a/build.gradle"
         def aClasspathResolved = aCompileClasspath.resolved as Map
@@ -201,7 +201,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
             dependencies == []
         }
 
-        def bCompileClasspath = jsonRepositorySnapshot(project: ":b", configuration: "compileClasspath")
+        def bCompileClasspath = jsonManifest("project :b")
         def bCompileClasspathFile = bCompileClasspath.file as Map
         bCompileClasspathFile.source_location == "b/build.gradle"
         def bClasspathResolved = bCompileClasspath.resolved as Map
@@ -216,7 +216,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
             dependencies == [this.fooGav]
         }
 
-        def cCompileClasspath = jsonRepositorySnapshot(project: ":c", configuration: "compileClasspath")
+        def cCompileClasspath = jsonManifest("project :c")
         def cCompileClasspathFile = cCompileClasspath.file as Map
         cCompileClasspathFile.source_location == "c/build.gradle"
         def cClasspathResolved = cCompileClasspath.resolved as Map
@@ -269,9 +269,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
 
         then:
         Map manifests = jsonManifests()
-        def buildSrcClasspath =
-            manifests[manifestKey(build: ":buildSrc", configuration: "buildScriptClasspath")] // Gradle 8+
-            ?: manifests[manifestKey(build: ":buildSrc", configuration: "runtimeClasspath")] // Gradle <=7
+        def buildSrcClasspath = manifests["project :buildSrc"]
 
         def buildSrcRuntimeFile = buildSrcClasspath.file as Map
         buildSrcRuntimeFile.source_location == "buildSrc/build.gradle"
@@ -282,7 +280,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
             relationship == "direct"
             dependencies == []
         }
-        def runtimeClasspath = jsonRepositorySnapshot(configuration: "runtimeClasspath")
+        def runtimeClasspath = jsonManifest("project :")
         def runtimeFile = runtimeClasspath.file as Map
         runtimeFile.source_location == "build.gradle"
         def runtimeClasspathResolved = runtimeClasspath.resolved as Map
@@ -330,7 +328,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
         succeeds("validate")
 
         then:
-        def runtimeClasspath = jsonRepositorySnapshot(configuration: "runtimeClasspath")
+        def runtimeClasspath = jsonManifest("project :")
         def runtimeFile = runtimeClasspath.file as Map
         verifyAll {
             runtimeFile.source_location == "build.gradle"
@@ -349,7 +347,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
             }
         }
         if (resolveIncludedBuild) {
-            def includedChildRuntimeClasspath = jsonRepositorySnapshot(build: ":included-child", configuration: "runtimeClasspath")
+            def includedChildRuntimeClasspath = jsonManifest("project :included-child")
             def includedChildRuntimeFile = includedChildRuntimeClasspath.file as Map
             verifyAll {
                 includedChildRuntimeFile.source_location == "included-child/build.gradle"

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
@@ -21,13 +21,7 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         succeeds("build")
 
         then:
-        resolvedConfigurations == [
-                "project : [annotationProcessor]",
-                "project : [compileClasspath]",
-                "project : [testAnnotationProcessor]",
-                "project : [testCompileClasspath]",
-                "project : [testRuntimeClasspath]"
-        ]
+        manifestNames == ["project :"]
     }
 
     def "check java-multi-project sample"() {
@@ -39,23 +33,11 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         succeeds("build")
 
         then:
-        resolvedConfigurations == [
-                "project :app [annotationProcessor]",
-                "project :app [compileClasspath]",
-                "project :app [runtimeClasspath]",
-                "project :app [testAnnotationProcessor]",
-                "project :app [testCompileClasspath]",
-                "project :app [testRuntimeClasspath]",
-                "project :buildSrc [annotationProcessor]",
-                "project :buildSrc [buildScriptClasspath]",
-                "project :buildSrc [compileClasspath]",
-                "project :list [annotationProcessor]",
-                "project :list [compileClasspath]",
-                "project :list [testAnnotationProcessor]",
-                "project :list [testCompileClasspath]",
-                "project :list [testRuntimeClasspath]",
-                "project :utilities [annotationProcessor]",
-                "project :utilities [compileClasspath]"
+        manifestNames == [
+                "project :app",
+                "project :buildSrc",
+                "project :list",
+                "project :utilities"
         ]
     }
 
@@ -68,36 +50,15 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         succeeds("build")
 
         then:
-        resolvedConfigurations == [
-                "project :app [annotationProcessor]",
-                "project :app [classpath]",
-                "project :app [compileClasspath]",
-                "project :app [runtimeClasspath]",
-                "project :app [testAnnotationProcessor]",
-                "project :app [testCompileClasspath]",
-                "project :app [testRuntimeClasspath]",
-                "project :build-logic [annotationProcessor]",
-                "project :build-logic [classpath]",
-                "project :build-logic [compileClasspath]",
-                "project :list [annotationProcessor]",
-                "project :list [classpath]",
-                "project :list [compileClasspath]",
-                "project :utilities [annotationProcessor]",
-                "project :utilities [classpath]",
-                "project :utilities [compileClasspath]",
-                "project :utilities [testAnnotationProcessor]",
-                "project :utilities [testCompileClasspath]",
-                "project :utilities [testRuntimeClasspath]"
+        manifestNames == [
+                "project :app",
+                "project :build-logic",
+                "project :list",
+                "project :utilities"
         ]
     }
 
-    private List<String> getResolvedConfigurations() {
-        Set<String> resolved = jsonManifests().keySet()
-        return resolved
-                // `buildSrc` resolution changed in Gradle 8.x
-                .collect { it == "project :buildSrc [runtimeClasspath]"
-                            ? "project :buildSrc [buildScriptClasspath]"
-                            : it }
-                .sort()
+    private List<String> getManifestNames() {
+        return jsonManifests().keySet() as List
     }
 }


### PR DESCRIPTION
The GitHub Repository Snapshot model allows the submission of any number of "manifests", which would normally represent a single source of dependency versions in a repository. (eg for NPM, each 'package.json' would represent a "manifest".

With this PR, instead of mapping each resolved dependency configuration to a separate manifest we instead map all resolved dependencies for a Gradle project to a manifest. This makes the model easier to understand, since dependencies are normally defined at the project level (or at a higher level for an entire build). Since we don't (yet) have any way to determine exactly where a dependency version is configured, we assume the project level for now.