### PR TITLE
Support dependencies resolved outside of a Project context

### DIFF
--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
@@ -50,13 +50,13 @@ abstract class BaseExtractorTest extends Specification {
     SimpleGradleExecuter createExecuter() {
         // Create a new JsonManifestLoader for each invocation of the executer
         File manifestFile =
-                testDirectory.file("build/reports/github-dependency-report/github-dependency-manifest.json")
+            testDirectory.file("build/reports/github-dependency-report/github-dependency-manifest.json")
         loader = new JsonRepositorySnapshotLoader(manifestFile)
         return createExecuter(testGradleVersion)
     }
 
     static String getTestGradleVersion() {
-        System.getProperty("testGradleVersion", GradleVersion.current().version)
+        return System.getProperty("testGradleVersion", GradleVersion.current().version)
     }
 
     static settingsPluginsAreSupported() {
@@ -70,29 +70,30 @@ abstract class BaseExtractorTest extends Specification {
     }
 
     TestFile getTestDirectory() {
-        new TestFile(testDir)
+        return new TestFile(testDir)
     }
 
     TestFile file(Object... path) {
         if (path.length == 1 && path[0] instanceof TestFile) {
             return path[0] as TestFile
         }
-        getTestDirectory().file(path)
+        return getTestDirectory().file(path)
     }
 
     protected BuildResult run() {
-        run("dependencyExtractor_resolveAllDependencies")
+        return run("dependencyExtractor_resolveAllDependencies")
     }
 
     protected BuildResult run(String... names) {
         executer.withTasks(names)
         result = getExecuter().run()
+        return result
     }
 
     @CompileDynamic
     protected void applyExtractorPlugin() {
         File pluginJar = TEST_CONFIG.asFile("extractorPlugin.jar.path")
-        String cleanedAbsolutePath = pluginJar.absolutePath.replace('\\',  '/')
+        String cleanedAbsolutePath = pluginJar.absolutePath.replace('\\', '/')
         assert (pluginJar.exists())
         file("init.gradle") << """
         import org.gradle.github.dependency.GitHubDependencySubmissionPlugin
@@ -221,7 +222,7 @@ abstract class BaseExtractorTest extends Specification {
                 final String newline = System.lineSeparator()
                 final String violationMessage = createViolationMessage(newline, validationMessages)
                 throw new AssertionError(
-                        ("Dependency constraints contains schema violations:" + newline + violationMessage) as Object
+                    ("Dependency constraints contains schema violations:" + newline + violationMessage) as Object
                 )
             }
         }
@@ -229,25 +230,25 @@ abstract class BaseExtractorTest extends Specification {
         @CompileDynamic
         private static String createViolationMessage(String newline, Set<ValidationMessage> validationMessages) {
             return validationMessages
-                    .stream()
-                    .map(ValidationMessage::getMessage)
-                    .collect(Collectors.joining(newline + "  - ", "  - ", ""))
+                .stream()
+                .map(ValidationMessage::getMessage)
+                .collect(Collectors.joining(newline + "  - ", "  - ", ""))
         }
 
         private static JsonSchema createSchemaValidator() {
             final JsonSchemaFactory factory =
-                    JsonSchemaFactory
-                            .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
-                            .build()
+                JsonSchemaFactory
+                    .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
+                    .build()
             try {
                 return factory
-                        .getSchema(
-                                JsonRepositorySnapshotLoader.class.classLoader.getResourceAsStream(SCHEMA)
-                        )
+                    .getSchema(
+                        JsonRepositorySnapshotLoader.class.classLoader.getResourceAsStream(SCHEMA)
+                    )
             } catch (JsonSchemaException ex) {
                 throw new RuntimeException(
-                        "Unable to load dependency constraints schema (resource: " + SCHEMA + ")",
-                        ex
+                    "Unable to load dependency constraints schema (resource: " + SCHEMA + ")",
+                    ex
                 )
             }
         }
@@ -268,19 +269,18 @@ abstract class BaseExtractorTest extends Specification {
 
         Map<String, String> asEnvironmentMap() {
             return [
-                    "GITHUB_JOB"       : job,
-                    "GITHUB_RUN_NUMBER": runNumber,
-                    "GITHUB_REF"       : ref,
-                    "GITHUB_SHA"       : sha,
-                    "GITHUB_WORKSPACE" : workspace,
-                    "GITHUB_REPOSITORY": gitHubRepository,
-                    "GITHUB_TOKEN"     : gitHubToken
+                "GITHUB_JOB"       : job,
+                "GITHUB_RUN_NUMBER": runNumber,
+                "GITHUB_REF"       : ref,
+                "GITHUB_SHA"       : sha,
+                "GITHUB_WORKSPACE" : workspace,
+                "GITHUB_REPOSITORY": gitHubRepository,
+                "GITHUB_TOKEN"     : gitHubToken
             ]
         }
 
         private static String fakeSha() {
-            Hashing.sha1().hashString(UUID.toString().toString()).toString()
+            return Hashing.sha1().hashString(UUID.toString().toString()).toString()
         }
-
     }
 }

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
@@ -106,8 +106,13 @@ abstract class BaseExtractorTest extends Specification {
 
     protected String purlFor(org.gradle.test.fixtures.Module module) {
         // NOTE: Don't use this in production, this is purely for test code. The escaping here may be insufficient.
+        return purlFor(module.group, module.module, module.version)
+    }
+
+    protected String purlFor(String group, String module, String version) {
+        // NOTE: Don't use this in production, this is purely for test code. The escaping here may be insufficient.
         String repositoryUrlEscaped = URLEncoder.encode(mavenRepo.rootDir.toURI().toASCIIString(), "UTF-8")
-        return "pkg:maven/${module.group}/${module.module}@${module.version}?repository_url=$repositoryUrlEscaped"
+        return "pkg:maven/${group}/${module}@${version}?repository_url=$repositoryUrlEscaped"
     }
 
     @CompileDynamic
@@ -172,7 +177,9 @@ abstract class BaseExtractorTest extends Specification {
                 def actual = resolved[key]
                 def expected = expectedResolved[key]
 
-                assert actual.package_url == expected.package_url
+                if (expected.package_url != null) {
+                    assert actual.package_url == expected.package_url
+                }
                 assert actual.relationship == (expected.relationship ?: "direct")
                 assert actual.dependencies == (expected.dependencies ?: [])
             }

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/BaseExtractorTest.groovy
@@ -52,8 +52,15 @@ abstract class BaseExtractorTest extends Specification {
         File manifestFile =
                 testDirectory.file("build/reports/github-dependency-report/github-dependency-manifest.json")
         loader = new JsonRepositorySnapshotLoader(manifestFile)
-        def gradleVersion = System.getProperty("testGradleVersion", GradleVersion.current().version)
-        return createExecuter(gradleVersion)
+        return createExecuter(testGradleVersion)
+    }
+
+    static String getTestGradleVersion() {
+        System.getProperty("testGradleVersion", GradleVersion.current().version)
+    }
+
+    static settingsPluginsAreSupported() {
+        return GradleVersion.version(testGradleVersion) >= GradleVersion.version("6.0")
     }
 
     SimpleGradleExecuter createExecuter(String gradleVersion) {

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/MultiProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/MultiProjectDependencyExtractorTest.groovy
@@ -46,7 +46,7 @@ class MultiProjectDependencyExtractorTest extends BaseExtractorTest {
                     implementation 'org.test:foo:1.0'
                 }
             }
-"""
+        """
 
         when:
         run()

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/PluginDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/PluginDependencyExtractorTest.groovy
@@ -1,0 +1,196 @@
+package org.gradle.github.dependency.extractor
+
+
+import org.gradle.test.fixtures.PluginPublisher
+import org.gradle.test.fixtures.file.TestFile
+
+class PluginDependencyExtractorTest extends BaseExtractorTest {
+    private static final SETTINGS_PLUGIN = "my.settings.plugin"
+    private static final PROJECT_PLUGIN_1 = "my.project.plugin1"
+    private static final PROJECT_PLUGIN_2 = "my.project.plugin2"
+
+    private File settingsFile
+    private File buildFile
+
+    def setup() {
+        applyExtractorPlugin()
+        establishEnvironmentVariables()
+
+        mavenRepo.module("org.test", "foo", "1.0").publish()
+        mavenRepo.module("org.test", "bar", "1.0").publish()
+
+        def pluginPublisher = new PluginPublisher(mavenRepo, testDirectory)
+        pluginPublisher.publishSettingsPlugin("settingPlugin", SETTINGS_PLUGIN, "implementation 'org.test:foo:1.0'")
+        pluginPublisher.publishProjectPlugin("plugin1", PROJECT_PLUGIN_1)
+        pluginPublisher.publishProjectPlugin("plugin2", PROJECT_PLUGIN_2, "implementation 'org.test:bar:1.0'")
+
+        settingsFile = file("settings.gradle")
+        buildFile = file("build.gradle")
+    }
+
+    def "extracts all plugin dependencies from multi project build"() {
+        given:
+        createMultiProjectBuildWithPlugins(testDirectory)
+
+        when:
+        run()
+
+        then:
+        manifestNames == ["build :", "project :", "project :a"]
+        // Project ':b' is not reported, since the plugin is loaded in parent project
+
+        manifestHasSettingsPlugin("build :")
+        manifestHasPlugin1("project :")
+        manifestHasPlugin2("project :a")
+    }
+
+    def "extracts all plugin dependencies from multi project buildSrc build"() {
+        given:
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << "apply plugin: 'java'"
+
+        createMultiProjectBuildWithPlugins(file("buildSrc"))
+
+        when:
+        run()
+
+        then:
+        manifestNames == ["build :", "project :", "project :buildSrc", "project :buildSrc:a"]
+        manifestHasSettingsPlugin("build :")
+        manifestIsEmpty("project :")
+        manifestHasPlugin1("project :buildSrc")
+        manifestHasPlugin2("project :buildSrc:a")
+    }
+
+    def "extracts all plugin dependencies from multi project included build"() {
+        given:
+        settingsFile << "includeBuild 'included-child'"
+        buildFile << "apply plugin: 'java'"
+
+        createMultiProjectBuildWithPlugins(file("included-child"))
+
+        when:
+        run()
+
+        then:
+        manifestNames == ["build :", "project :", "project :included-child", "project :included-child:a"]
+        manifestHasSettingsPlugin("build :")
+        manifestIsEmpty("project :")
+        manifestHasPlugin1("project :included-child")
+        manifestHasPlugin2("project :included-child:a")
+    }
+
+    def "extracts all plugin dependencies from multi project included plugin build"() {
+        given:
+        settingsFile << """
+            pluginManagement {
+                includeBuild 'included-plugin'
+            }
+        """
+        buildFile << "apply plugin: 'java'"
+
+        createMultiProjectBuildWithPlugins(file("included-plugin"))
+
+        when:
+        run()
+
+        then:
+        manifestNames == ["build :", "project :", "project :included-plugin", "project :included-plugin:a"]
+        manifestHasSettingsPlugin("build :")
+        manifestIsEmpty("project :")
+        manifestHasPlugin1("project :included-plugin")
+        manifestHasPlugin2("project :included-plugin:a")
+    }
+
+    private void createMultiProjectBuildWithPlugins(TestFile rootDir) {
+        rootDir.file("settings.gradle") << """
+            pluginManagement {
+                repositories {
+                    maven { url '${mavenRepo.uri}' }
+                }
+            }
+            plugins {
+                id("$SETTINGS_PLUGIN") version("1.0")
+            }
+            include 'a', 'b'
+"""
+
+        rootDir.file("build.gradle") << """
+            plugins {
+                id("$PROJECT_PLUGIN_1") version("1.0")
+            }
+"""
+        rootDir.file("a/build.gradle") << """
+            plugins {
+                id("$PROJECT_PLUGIN_2") version("1.0")
+            }
+"""
+        rootDir.file("b/build.gradle") << """
+            plugins {
+                id("$PROJECT_PLUGIN_1") version("1.0")
+            }
+"""
+    }
+
+    private boolean manifestHasSettingsPlugin(String manifestName) {
+        gitHubManifest(manifestName).assertResolved([
+            "my.settings.plugin:my.settings.plugin.gradle.plugin:1.0": [
+                relationship: "direct",
+                dependencies: ["com.example:settingPlugin:1.0"]
+            ],
+            "com.example:settingPlugin:1.0"                          : [
+                relationship: "indirect",
+                dependencies: ["org.test:foo:1.0"]
+            ],
+            "org.test:foo:1.0"                                       : [
+                relationship: "indirect",
+                dependencies: []
+            ],
+
+            // The project plugins are resolved at build level without any transitive deps
+            "my.project.plugin1:my.project.plugin1.gradle.plugin:1.0": [
+                relationship: "direct",
+                dependencies: []
+            ],
+            "my.project.plugin2:my.project.plugin2.gradle.plugin:1.0": [
+                relationship: "direct",
+                dependencies: []
+            ]
+        ])
+    }
+
+    private boolean manifestHasPlugin1(String manifestName) {
+        gitHubManifest(manifestName).assertResolved([
+            "my.project.plugin1:my.project.plugin1.gradle.plugin:1.0": [
+                relationship: "direct",
+                dependencies: ["com.example:plugin1:1.0"]
+            ],
+            "com.example:plugin1:1.0"                                : [
+                relationship: "indirect",
+                dependencies: []
+            ]
+        ])
+    }
+
+    private boolean manifestHasPlugin2(String manifestName) {
+        gitHubManifest(manifestName).assertResolved([
+            "my.project.plugin2:my.project.plugin2.gradle.plugin:1.0": [
+                relationship: "direct",
+                dependencies: ["com.example:plugin2:1.0"]
+            ],
+            "com.example:plugin2:1.0"                                : [
+                relationship: "indirect",
+                dependencies: ["org.test:bar:1.0"]
+            ],
+            "org.test:bar:1.0"                                       : [
+                relationship: "indirect",
+                dependencies: []
+            ]
+        ])
+    }
+
+    private boolean manifestIsEmpty(String manifestName) {
+        gitHubManifest(manifestName).assertResolved([:])
+    }
+
+}

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/PluginDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/PluginDependencyExtractorTest.groovy
@@ -1,9 +1,7 @@
 package org.gradle.github.dependency.extractor
 
-
 import org.gradle.test.fixtures.PluginPublisher
 import org.gradle.test.fixtures.file.TestFile
-import org.gradle.util.GradleVersion
 
 class PluginDependencyExtractorTest extends BaseExtractorTest {
     private static final SETTINGS_PLUGIN = "my.settings.plugin"
@@ -108,7 +106,8 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
             plugins {
                 id("$SETTINGS_PLUGIN") version("1.0")
             }
-""" : ""
+        """ : ""
+
         rootDir.file("settings.gradle") << """
             pluginManagement {
                 repositories {
@@ -117,26 +116,28 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
             }
             $settingsPluginDeclaration
             include 'a', 'b'
-"""
+        """
 
         rootDir.file("build.gradle") << """
             plugins {
                 id("$PROJECT_PLUGIN_1") version("1.0")
             }
-"""
+        """
+
         rootDir.file("a/build.gradle") << """
             plugins {
                 id("$PROJECT_PLUGIN_2") version("1.0")
             }
-"""
+        """
+
         rootDir.file("b/build.gradle") << """
             plugins {
                 id("$PROJECT_PLUGIN_1")
             }
-"""
+        """
     }
 
-    private boolean manifestHasSettingsPlugin(String manifestName) {
+    private void manifestHasSettingsPlugin(String manifestName) {
         if (settingsPluginsAreSupported()) {
             gitHubManifest(manifestName).assertResolved([
                 "my.settings.plugin:my.settings.plugin.gradle.plugin:1.0": [
@@ -178,7 +179,7 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         }
     }
 
-    private boolean manifestHasPlugin1(String manifestName) {
+    private void manifestHasPlugin1(String manifestName) {
         gitHubManifest(manifestName).assertResolved([
             "my.project.plugin1:my.project.plugin1.gradle.plugin:1.0": [
                 relationship: "direct",
@@ -191,7 +192,7 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         ])
     }
 
-    private boolean manifestHasPlugin2(String manifestName) {
+    private void manifestHasPlugin2(String manifestName) {
         gitHubManifest(manifestName).assertResolved([
             "my.project.plugin2:my.project.plugin2.gradle.plugin:1.0": [
                 relationship: "direct",
@@ -208,7 +209,7 @@ class PluginDependencyExtractorTest extends BaseExtractorTest {
         ])
     }
 
-    private boolean manifestIsEmpty(String manifestName) {
+    private void manifestIsEmpty(String manifestName) {
         gitHubManifest(manifestName).assertResolved([:])
     }
 

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
@@ -3,7 +3,7 @@ package org.gradle.github.dependency.extractor
 import org.apache.commons.io.FileUtils
 import spock.lang.IgnoreIf
 
-@IgnoreIf({ System.getProperty("testGradleVersion") == "5.6.4"})
+@IgnoreIf({ System.getProperty("testGradleVersion") == "5.6.4" })
 // Samples aren't designed to run on Gradle 5.x
 class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
     def setup() {
@@ -24,18 +24,18 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         def buildManifest = jsonManifest("build :")
         def buildDependencies = (buildManifest.resolved as Map).keySet()
         buildDependencies.containsAll([
-                "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
+            "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
         ])
 
         def projectManifest = jsonManifest("project :")
         def projectDependencies = (projectManifest.resolved as Map).keySet()
         projectDependencies.containsAll([
-                "com.diffplug.spotless:spotless-plugin-gradle:4.5.1", // 'plugins' dependency
-                "com.diffplug.durian:durian-core:1.2.0", // transitive 'plugins' dependency
-                "org.apache.commons:commons-math3:3.6.1", // 'api' dependency
-                "com.google.guava:guava:31.1-jre", // 'implementation' dependency
-                "com.google.guava:failureaccess:1.0.1", // transitive 'implementation' dependency
-                "org.junit.jupiter:junit-jupiter:5.9.1" // testImplementation dependency
+            "com.diffplug.spotless:spotless-plugin-gradle:4.5.1", // 'plugins' dependency
+            "com.diffplug.durian:durian-core:1.2.0", // transitive 'plugins' dependency
+            "org.apache.commons:commons-math3:3.6.1", // 'api' dependency
+            "com.google.guava:guava:31.1-jre", // 'implementation' dependency
+            "com.google.guava:failureaccess:1.0.1", // transitive 'implementation' dependency
+            "org.junit.jupiter:junit-jupiter:5.9.1" // testImplementation dependency
         ])
     }
 
@@ -49,10 +49,10 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
 
         then:
         manifestNames == [
-                "project :app",
-                "project :buildSrc",
-                "project :list",
-                "project :utilities"
+            "project :app",
+            "project :buildSrc",
+            "project :list",
+            "project :utilities"
         ]
     }
 
@@ -66,10 +66,10 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
 
         then:
         manifestNames == [
-                "project :app",
-                "project :build-logic",
-                "project :list",
-                "project :utilities"
+            "project :app",
+            "project :build-logic",
+            "project :list",
+            "project :utilities"
         ]
     }
 }

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SampleProjectDependencyExtractorTest.groovy
@@ -20,7 +20,23 @@ class SampleProjectDependencyExtractorTest extends BaseExtractorTest {
         run()
 
         then:
-        manifestNames == ["project :"]
+        manifestNames == ["build :", "project :"]
+        def buildManifest = jsonManifest("build :")
+        def buildDependencies = (buildManifest.resolved as Map).keySet()
+        buildDependencies.containsAll([
+                "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
+        ])
+
+        def projectManifest = jsonManifest("project :")
+        def projectDependencies = (projectManifest.resolved as Map).keySet()
+        projectDependencies.containsAll([
+                "com.diffplug.spotless:spotless-plugin-gradle:4.5.1", // 'plugins' dependency
+                "com.diffplug.durian:durian-core:1.2.0", // transitive 'plugins' dependency
+                "org.apache.commons:commons-math3:3.6.1", // 'api' dependency
+                "com.google.guava:guava:31.1-jre", // 'implementation' dependency
+                "com.google.guava:failureaccess:1.0.1", // transitive 'implementation' dependency
+                "org.junit.jupiter:junit-jupiter:5.9.1" // testImplementation dependency
+        ])
     }
 
     def "check java-multi-project sample"() {

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SingleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SingleProjectDependencyExtractorTest.groovy
@@ -2,6 +2,7 @@ package org.gradle.github.dependency.extractor
 
 import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.PluginPublisher
+import spock.lang.IgnoreIf
 
 class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
     private MavenModule foo
@@ -342,6 +343,9 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
         ])
     }
 
+    @IgnoreIf({
+        !settingsPluginsAreSupported()
+    })
     def "extracts settings plugin dependency"() {
         given:
         new PluginPublisher(mavenRepo, testDirectory).publishSettingsPlugin("plugin", "my.settings.plugin")

--- a/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SingleProjectDependencyExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependency/extractor/SingleProjectDependencyExtractorTest.groovy
@@ -1,7 +1,7 @@
 package org.gradle.github.dependency.extractor
 
-import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.PluginPublisher
+import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.IgnoreIf
 
 class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
@@ -336,7 +336,7 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
                 package_url : purlFor("my.project.plugin", "my.project.plugin.gradle.plugin", "1.0"),
                 dependencies: ["com.example:plugin:1.0"]
             ],
-            "com.example:plugin:1.0": [
+            "com.example:plugin:1.0"                               : [
                 package_url : purlFor("com.example", "plugin", "1.0"),
                 relationship: "indirect"
             ]
@@ -373,7 +373,7 @@ class SingleProjectDependencyExtractorTest extends BaseExtractorTest {
                 package_url : purlFor("my.settings.plugin", "my.settings.plugin.gradle.plugin", "1.0"),
                 dependencies: ["com.example:plugin:1.0"]
             ],
-            "com.example:plugin:1.0": [
+            "com.example:plugin:1.0"                                 : [
                 package_url : purlFor("com.example", "plugin", "1.0"),
                 relationship: "indirect"
             ]

--- a/plugin-test/src/testFixtures/groovy/org/gradle/test/fixtures/PluginPublisher.groovy
+++ b/plugin-test/src/testFixtures/groovy/org/gradle/test/fixtures/PluginPublisher.groovy
@@ -1,0 +1,75 @@
+package org.gradle.test.fixtures
+
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.maven.MavenRepository
+import org.gradle.util.GradleVersion
+
+class PluginPublisher {
+    private final MavenRepository mavenRepo
+    private final TestFile rootDir
+
+    PluginPublisher(MavenRepository mavenRepo, TestFile rootDir) {
+        this.mavenRepo = mavenRepo
+        this.rootDir = rootDir
+    }
+
+    void publishSettingsPlugin(String pluginModule, String pluginId, String pluginDependencies = "") {
+        publishPlugin(pluginModule, pluginId, "org.gradle.api.initialization.Settings", pluginDependencies)
+    }
+
+    void publishProjectPlugin(String pluginModule, String pluginId, String pluginDependencies = "") {
+        publishPlugin(pluginModule, pluginId, "org.gradle.api.Project", pluginDependencies)
+    }
+
+    private void publishPlugin(String pluginModule, String pluginId, String pluginTarget, String pluginDependencies) {
+        rootDir.file( pluginModule, "src/main/java/Plugin_${pluginModule}.java") << """
+            import org.gradle.api.Plugin;
+
+            public class Plugin_${pluginModule} implements Plugin<$pluginTarget> {
+                @Override
+                public void apply($pluginTarget target) {
+                    System.out.println("${pluginId} from repository applied");
+                }
+            }
+        """
+        rootDir.file(pluginModule, "settings.gradle") << "rootProject.name='$pluginModule'"
+        rootDir.file(pluginModule, "build.gradle") << """
+            plugins {
+                id("java-gradle-plugin")
+                id("maven-publish")
+            }
+            group = "com.example"
+            version = "1.0"
+            repositories {
+                maven { url '${mavenRepo.uri}' }
+            }
+            dependencies {
+                $pluginDependencies
+            }
+            publishing {
+                repositories {
+                    maven { url '${mavenRepo.uri}' }
+                }
+            }
+            gradlePlugin {
+                plugins {
+                    publishedPlugin {
+                        id = '${pluginId}'
+                        implementationClass = 'Plugin_${pluginModule}'
+                    }
+                }
+            }
+        """
+
+
+        def pluginDir = rootDir.file(pluginModule)
+
+        def executer = new SimpleGradleExecuter(pluginDir, rootDir.file("test-kit"), GradleVersion.current().version)
+        executer.withTasks("publish").run()
+        pluginDir.forceDeleteDir()
+
+        mavenRepo.module("com.example", pluginModule, "1.0").pomFile.assertExists()
+    }
+
+}
+

--- a/plugin/src/main/kotlin/org/gradle/github/dependency/extractor/internal/model/ResolvedConfiguration.kt
+++ b/plugin/src/main/kotlin/org/gradle/github/dependency/extractor/internal/model/ResolvedConfiguration.kt
@@ -1,11 +1,11 @@
 package org.gradle.github.dependency.extractor.internal.model
 
-data class ResolvedConfiguration(val rootId: String, val identityPath: String, val name: String, val components: MutableList<ResolvedComponent> = mutableListOf()) {
+data class ResolvedConfiguration(val buildPath: String, val identityPath: String?, val configName: String, val components: MutableList<ResolvedComponent> = mutableListOf()) {
     fun hasComponent(componentId: String): Boolean {
         return components.map { it.id }.contains(componentId)
     }
 
     fun getRootComponent(): ResolvedComponent {
-        return components.find { it.id == rootId }!!
+        return components.first()
     }
 }

--- a/sample-projects/java-single-project/build.gradle
+++ b/sample-projects/java-single-project/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java-library'
+    id 'com.diffplug.gradle.spotless' version '4.5.1'
 }
 
 repositories {

--- a/sample-projects/java-single-project/settings.gradle
+++ b/sample-projects/java-single-project/settings.gradle
@@ -1,1 +1,4 @@
+plugins {
+    id 'com.gradle.enterprise' version '3.12.6'
+}
 rootProject.name = 'java-lib'


### PR DESCRIPTION
Previously, we were ignoring any dependency resolution that occurred outside the
context of a Gradle Project. This meant that any dependencies resolved in the
context of a Settings script were not being captured.

By tracking the 'buildPath' and the 'projectPath' separately, we can now collect
all dependency resolution.

Due to a limitation in the events being processed, all non-project resolution will
be allocated to a single manifest for the entire build process. It may be possible
later to make this more precise, and assign resolution to a specific build process.