### PR TITLE
Bump Jackson to 2.18.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ spock = "2.4-groovy-3.0"
 kotlin = "1.8.10"
 
 [libraries]
-jackson-platform = { group = "com.fasterxml.jackson", name = "jackson-bom", version = "2.14.2" } # Cannot upgrade to 2.15.x, due to https://github.com/gradle/gradle/issues/24390
+jackson-platform = { group = "com.fasterxml.jackson", name = "jackson-bom", version = "2.18.8" } # Java 17/21 multi-release classes are stripped from the shaded jar so old Gradle can load it
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind" }
 jackson-parameter-names = { group = "com.fasterxml.jackson.module", name = "jackson-module-parameter-names" }
 jackson-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin" }
@@ -26,6 +26,6 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2" }
 
 [plugins]
-shadow-jar = { id = "com.github.johnrengelman.shadow", version = "8.1.1"}
+shadow-jar = { id = "com.gradleup.shadow", version = "8.3.6"}
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.0" }
 github-release = { id = "com.github.breadmoirai.github-release", version = "2.5.2"}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -49,10 +49,10 @@ dependencies {
     shadowImplementation(libs.jackson.databind)
     shadowImplementation(libs.jackson.kotlin) {
         version {
-            strictly("2.12.3")
+            strictly("2.18.8")
         }
         exclude(group = "org.jetbrains.kotlin")
-        because("kotlin std lib is bundled with Gradle. 2.12.3 because higher versions depend upon Kotlin 1.5")
+        because("kotlin std lib is bundled with Gradle; pinned to match jackson-databind")
     }
     shadowImplementation(libs.github.packageurl)
 
@@ -93,6 +93,8 @@ tasks.withType<PluginUnderTestMetadata>().configureEach {
 
 val shadowJarTask = tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier = ""
+    exclude("META-INF/versions/17/**")
+    exclude("META-INF/versions/21/**")
     configurations = listOf(shadowImplementation)
     val projectGroup = project.group
     doFirst {


### PR DESCRIPTION
Bumps Jackson 2.14.2 → 2.18.8 (with jackson-module-kotlin pinned to match and gradleup shadow 8.3.6). Java 17/21 multi-release classes are stripped from the shaded jar so old Gradle can still load it.

CVEs found by grype on the stock 2.14.2 shaded jar (all fixed except the last, which is only patched in the unreleased 2.18.9):

| Package | Severity | ID | Fixed by 2.18.8 |
|---|---|---|---|
| jackson-core | High | CVE-2025-52999 | yes |
| jackson-core | Medium | GHSA-72hv-8253-57qq | yes |
| jackson-databind | High | CVE-2026-54512 | yes |
| jackson-databind | High | CVE-2026-54513 | yes |
| jackson-databind | Medium | CVE-2026-54514 | yes |
| jackson-databind | Medium | CVE-2026-54515 | no (2.18.9) |
