### PR TITLE
Decouple build JDK from test JDK; upgrade shadow to 9.2.2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -80,15 +80,14 @@ jobs:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       # -PtestJavaVersion runs the :plugin-test module (and thus the Gradle version under test) on
-      # the matrix JDK via a Gradle toolchain. That JDK is already installed on the runner and
-      # exposed as JAVA_HOME_<version>_X64; org.gradle.java.installations.fromEnv points Gradle's
-      # toolchain detection at it (auto-detection does not scan the runner tool cache on its own).
+      # the matrix JDK via a Gradle toolchain. The matrix JDKs are preinstalled on the runner;
+      # relying here on Gradle toolchain auto-detection to locate them (auto-download is disabled,
+      # so a missing toolchain fails the build rather than provisioning one).
       - name: Execute Gradle Build
         run: >
           ./gradlew -S build
           -DtestGradleVersion=${{ matrix.gradle-version }}
           -PtestJavaVersion=${{ matrix.java-version }}
-          -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java-version }}_X64
 
   # Aggregates the test-gradle-version matrix into a single status check.
   # Enable "merge when checks pass" / branch protection against this job rather than

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-            java-version: 11
+            java-version: 17
             distribution: temurin
 
       - name: Setup Gradle
@@ -35,7 +35,10 @@ jobs:
     needs: quick-check
     strategy:
       fail-fast: false
-      # Test earliest and latest supported version of 5.x, 6.x, 7.x, and 8.x
+      # Test earliest and latest supported version of 5.x, 6.x, 7.x, and 8.x.
+      # The plugin fatjar is always built with a fixed, modern JDK (see "Set up JDK" below);
+      # java-version here is only the JDK that each Gradle version under test runs on, selected
+      # via a Gradle toolchain (-PtestJavaVersion). Older Gradle versions require older JDKs.
       matrix:
         include:
           - gradle-version: "5.2.1"
@@ -62,10 +65,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Fixed build JDK: compiles the plugin and builds the shadow fatjar. Must satisfy the build
+      # tooling's own JDK requirement (the shadow plugin needs Java 17+), independent of the older
+      # JDK the Gradle version under test runs on.
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 17
           distribution: temurin
 
       - name: Setup Gradle
@@ -73,8 +79,16 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
+      # -PtestJavaVersion runs the :plugin-test module (and thus the Gradle version under test) on
+      # the matrix JDK via a Gradle toolchain. That JDK is already installed on the runner and
+      # exposed as JAVA_HOME_<version>_X64; org.gradle.java.installations.fromEnv points Gradle's
+      # toolchain detection at it (auto-detection does not scan the runner tool cache on its own).
       - name: Execute Gradle Build
-        run: ./gradlew -S build -DtestGradleVersion=${{ matrix.gradle-version }}
+        run: >
+          ./gradlew -S build
+          -DtestGradleVersion=${{ matrix.gradle-version }}
+          -PtestJavaVersion=${{ matrix.java-version }}
+          -Dorg.gradle.java.installations.fromEnv=JAVA_HOME_${{ matrix.java-version }}_X64
 
   # Aggregates the test-gradle-version matrix into a single status check.
   # Enable "merge when checks pass" / branch protection against this job rather than
@@ -101,7 +115,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-            java-version: 11
+            java-version: 17
             distribution: temurin
 
       - name: Setup Gradle

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,9 @@ org.gradle.jvmargs=-Xmx5000m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 
+# Never auto-provision JDKs for toolchains: the required JDKs are expected to be already installed
+# (auto-detected locally, exposed via org.gradle.java.installations.fromEnv on CI). Downloading would
+# mask a misconfigured -PtestJavaVersion instead of failing fast.
+org.gradle.java.installations.auto-download=false
+
 systemProp.gradle.publish.skip.namespace.check=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,5 +25,5 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2" }
 
 [plugins]
-shadow-jar = { id = "com.gradleup.shadow", version = "8.3.6"}
+shadow-jar = { id = "com.gradleup.shadow", version = "9.2.2"}
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.0" }

--- a/plugin-test/build.gradle.kts
+++ b/plugin-test/build.gradle.kts
@@ -38,6 +38,24 @@ sourceSets.test {
     resources.srcDir(writeTestConfig.map { it.generatedResourceDirectory })
 }
 
+// Compile and run this module (and thus the Gradle version under test) on a specific JDK with
+// -PtestJavaVersion=8, decoupled from the JDK used to build the :plugin fatjar. This lets the
+// plugin be built with a fixed, modern JDK (as required by newer build tooling such as the
+// shadow plugin) while still exercising older Gradle versions on the older JDKs they require.
+// Test classes must be *compiled* for the test JDK too, not just executed on it, so we set a
+// project-wide toolchain rather than only the test task's launcher. When unset, the module uses
+// the JDK that is building the project.
+val testJavaVersion = providers.gradleProperty("testJavaVersion")
+    .map { JavaLanguageVersion.of(it.toInt()) }
+
+if (testJavaVersion.isPresent) {
+    java {
+        toolchain {
+            languageVersion = testJavaVersion.get()
+        }
+    }
+}
+
 tasks.withType<Test>().configureEach {
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -3,7 +3,6 @@ import com.gradle.publish.PublishTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.util.jar.JarFile
 
 // Upgrade transitive dependencies in plugin classpath
 buildscript {
@@ -92,25 +91,11 @@ val shadowJarTask = tasks.named<ShadowJar>("shadowJar") {
     // Gradle versions. See https://github.com/gradle/gradle/issues/24390
     exclude("META-INF/versions/**")
     configurations = listOf(shadowImplementation)
-    val projectGroup = project.group
-    doFirst {
-        configurations.forEach { configuration ->
-            configuration.files.forEach { jar ->
-                JarFile(jar).use { jf ->
-                    jf.entries().iterator().forEach { entry ->
-                        if (entry.name.endsWith(".class") && entry.name != "module-info.class") {
-                            val packageName =
-                                entry
-                                    .name
-                                    .substring(0..entry.name.lastIndexOf('/'))
-                                    .replace('/', '.')
-                            relocate(packageName, "${projectGroup}.shadow.$packageName")
-                        }
-                    }
-                }
-            }
-        }
-    }
+    // Relocate every bundled package under `<group>.shadow.` so the plugin's own dependencies can
+    // never clash with those of the build it is applied to. shadow 9.x does this natively via
+    // auto-relocation, replacing the manual per-package relocation loop we maintained previously.
+    enableAutoRelocation = true
+    relocationPrefix = "${project.group}.shadow"
 }
 
 configurations.archives.get().artifacts.clear()


### PR DESCRIPTION
## Problem

The `test-gradle-version` matrix built the plugin fatjar **and** ran the TestKit tests with a single JDK per row. Because the oldest supported Gradle (5.x) must run on JDK 8, the whole build toolchain — including the shadow plugin — was pinned to JDK 8. That blocked upgrading shadow, whose recent releases require Java 17+.

Only the *tests* actually need the old JDK (old Gradle can't run on new JDKs). The fatjar targets Java 8 bytecode and can be built on any modern JDK.

## Change

Split the two concerns:

- **Build** the plugin fatjar with a fixed, modern JDK (17) in every job.
- **Test** the `:plugin-test` module (and thus the Gradle version under test) on the JDK that version requires, selected via a Gradle **toolchain** (`-PtestJavaVersion`). The module is *compiled* for that JDK too, not just executed on it.

The matrix JDKs are already preinstalled on the runner and are found by Gradle's toolchain **auto-detection** — no explicit `installations.paths`/`fromEnv` needed. `org.gradle.java.installations.auto-download=false` guarantees a missing toolchain fails the build loudly rather than being silently provisioned.

With the build freed from old JDKs:

- Bump **shadow `8.3.6` → `9.2.2`** — the latest that keeps the Gradle `8.14.4` wrapper (shadow `9.3+` requires Gradle 9).
- Shadow 9 exposes `configurations` as a `SetProperty` and ships native auto-relocation, so the manual per-package relocation loop is replaced with `enableAutoRelocation` + `relocationPrefix`. Verified the resulting fatjar is structurally equivalent (all bundled deps under `org.gradle.shadow.`, no un-relocated leaks, `META-INF/versions` stripped).

`quick-check` and `self-test` build JDK bumped `11 → 17` (shadow's runtime requirement).

## Verification

Both approaches were run green on CI across all 10 matrix rows + `quick-check` + `self-test`:

- **With `fromEnv`** (initial commit): full matrix green.
- **Auto-detection only** (final commit, `fromEnv` removed): full matrix green. Conclusive because `auto-download=false` — the `5.2.1`/`5.6.4` rows on JDK 8 could only pass if the toolchain genuinely resolved to a preinstalled JDK 8 (old Gradle cannot run on JDK 17). So auto-detection locates the runner's JDKs; the explicit `fromEnv` is unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)