### PR TITLE
Upgrade shadow to 9.4.3 and drop redundant vulnerability constraints

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-datab
 jackson-parameter-names = { group = "com.fasterxml.jackson.module", name = "jackson-module-parameter-names" }
 
 apache-commons-io = { group = "commons-io", name = "commons-io", version = "2.21.0" }
-apache-log4j-core = { group = "org.apache.logging.log4j", name = "log4j-core", version = "2.25.4" }
 
 github-packageurl = { group = "com.github.package-url", name = "packageurl-java", version = "1.5.0" }
 
@@ -25,5 +24,5 @@ jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version
 google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2" }
 
 [plugins]
-shadow-jar = { id = "com.gradleup.shadow", version = "9.2.2"}
+shadow-jar = { id = "com.gradleup.shadow", version = "9.4.3"}
 plugin-publish = { id = "com.gradle.plugin-publish", version = "2.1.0" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -4,21 +4,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-// Upgrade transitive dependencies in plugin classpath
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        constraints {
-            // The com.gradleup.shadow plugin depends on vulnerable library releases.
-            // We constrain these to newer, patched versions.
-            classpath(libs.apache.commons.io)
-            classpath(libs.apache.log4j.core)
-        }
-    }
-}
-
 plugins {
     kotlin("jvm") version(libs.versions.kotlin)
     alias(libs.plugins.plugin.publish)


### PR DESCRIPTION
## What

- Bump `com.gradleup.shadow` **9.2.2 → 9.4.3** (latest release).
- Remove the `buildscript { … constraints { … } }` block in `plugin/build.gradle.kts` that forced patched `commons-io` / `log4j-core` versions.
- Drop the `apache-log4j-core` version-catalog entry (its only consumer was that constraint). `apache-commons-io` is kept — it's still used by `plugin-test`.

## Why

Shadow 9.4.3 now ships patched transitive dependencies natively (`commons-io:2.22.0`, `log4j-core:2.26.0`), which are newer than the versions the constraints pinned. The constraints had become no-ops, so they're removed along with the now-unused catalog entry.

## Gradle version

Left at **8.14.4**. The latest shadow does *not* require Gradle 9 — 9.4.3 builds and tests cleanly on 8.14.4 — so no Gradle bump is needed and the plugin's Gradle 5 runtime compatibility is unaffected.

Note: this does not remove the `org.gradle.api.plugins.Convention` deprecation warning — that originates from the Kotlin Gradle plugin (1.8.10), not shadow.

## Verification

- `:plugin:test` ✅
- `:plugin-test:test` (integration suite) ✅
- `:plugin:shadowJar` ✅ — buildscript classpath still resolves `commons-io:2.22.0` / `log4j-core:2.26.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)