### PR TITLE
Update json-schema-validator to 2.0.3 and migrate to its new API

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ junit-junit4 = { group = "junit", name = "junit", version = "4.13.2" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.14.3" }
 
 groovy-json = { group = "org.codehaus.groovy", name = "groovy-json", version = "3.0.25" }
-json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version = "1.5.9" }
+json-schema-validator = { group = "com.networknt", name = "json-schema-validator", version = "2.0.3" }
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version = "26.1.0" }
 google-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.2" }
 

--- a/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
+++ b/plugin-test/src/test/groovy/org/gradle/github/dependencygraph/BaseExtractorTest.groovy
@@ -2,7 +2,11 @@ package org.gradle.github.dependencygraph
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.*
+import com.networknt.schema.Error
+import com.networknt.schema.Schema
+import com.networknt.schema.SchemaException
+import com.networknt.schema.SchemaRegistry
+import com.networknt.schema.SpecificationVersion
 import groovy.json.JsonSlurper
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
@@ -251,15 +255,15 @@ abstract class BaseExtractorTest extends Specification {
         protected Map jsonRepositorySnapshot() {
             def jsonSlurper = new JsonSlurper()
             println(dependencyGraphFile.text)
-            JsonSchema schema = createSchemaValidator()
+            Schema schema = createSchemaValidator()
             ObjectMapper mapper = new ObjectMapper()
             JsonNode node = mapper.readTree(dependencyGraphFile)
             validateAgainstJsonSchema(schema, node)
             return jsonSlurper.parse(dependencyGraphFile) as Map
         }
 
-        private static void validateAgainstJsonSchema(JsonSchema schema, JsonNode json) {
-            final Set<ValidationMessage> validationMessages = schema.validate(json)
+        private static void validateAgainstJsonSchema(Schema schema, JsonNode json) {
+            final List<Error> validationMessages = schema.validate(json)
             if (!validationMessages.isEmpty()) {
                 final String newline = System.lineSeparator()
                 final String violationMessage = createViolationMessage(newline, validationMessages)
@@ -270,24 +274,22 @@ abstract class BaseExtractorTest extends Specification {
         }
 
         @CompileDynamic
-        private static String createViolationMessage(String newline, Set<ValidationMessage> validationMessages) {
+        private static String createViolationMessage(String newline, List<Error> validationMessages) {
             return validationMessages
                 .stream()
-                .map(ValidationMessage::getMessage)
+                .map(Error::getMessage)
                 .collect(Collectors.joining(newline + "  - ", "  - ", ""))
         }
 
-        private static JsonSchema createSchemaValidator() {
-            final JsonSchemaFactory factory =
-                JsonSchemaFactory
-                    .builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V4))
-                    .build()
+        private static Schema createSchemaValidator() {
+            final SchemaRegistry registry =
+                SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_4)
             try {
-                return factory
+                return registry
                     .getSchema(
                         JsonRepositorySnapshotLoader.class.classLoader.getResourceAsStream(SCHEMA)
                     )
-            } catch (JsonSchemaException ex) {
+            } catch (SchemaException ex) {
                 throw new RuntimeException(
                     "Unable to load dependency constraints schema (resource: " + SCHEMA + ")",
                     ex


### PR DESCRIPTION
## What

Bumps `com.networknt:json-schema-validator` **1.5.9 → 2.0.3** and migrates the test schema-validation helper (`BaseExtractorTest`) to the new 2.x API.

This unblocks the Dependabot group update in #223, whose `json-schema-validator` bump was failing to compile (`unable to resolve class JsonSchema` and friends). The other four dependencies in that group are unrelated and can be handled by Dependabot as usual.

## Why the source changes are needed

json-schema-validator 2.x is a breaking release that renames the core types out of the old `com.networknt.schema.*` surface:

| 1.5.9 | 2.0.3 |
| --- | --- |
| `JsonSchema` | `Schema` |
| `JsonSchemaFactory` | `SchemaRegistry` |
| `ValidationMessage` | `Error` |
| `JsonSchemaException` | `SchemaException` |
| `SpecVersion.VersionFlag.V4` | `SpecificationVersion.DRAFT_4` |
| `JsonSchemaFactory.builder(getInstance(...)).build()` | `SchemaRegistry.withDefaultDialect(...)` |
| `schema.validate()` → `Set<ValidationMessage>` | `schema.validate()` → `List<Error>` |

Imports are now explicit rather than a wildcard, so that the new `com.networknt.schema.Error` correctly shadows `java.lang.Error`.

## Why 2.0.3 and not 3.x

The 3.x line requires Jackson 3; this project is on Jackson 2. Dependabot's config already ignores json-schema-validator major v3, so 2.0.3 is the correct Jackson-2-compatible target.

## Verification

- `:plugin-test:test` (full integration suite, which exercises the schema validation path) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)